### PR TITLE
refactor: reuse more code when processing symbols

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -33,7 +33,7 @@ export async function insertMethodNode(method) {
   await session.run(
     "MERGE (m:Method {id: $id}) ON CREATE SET m.name = $name, m.range = $range, m.source = $source",
     {
-      id: method.identifier,
+      id: method.id,
       name: method.name,
       range: JSON.stringify(method.range) || "",
       source: method.source || "",
@@ -47,7 +47,7 @@ export async function insertClassNode(classNode) {
   await session.run(
     "MERGE (c:Class {id: $id}) ON CREATE SET c.name = $name, c.range = $range, c.source = $source",
     {
-      id: classNode.identifier,
+      id: classNode.id,
       name: classNode.name,
       range: JSON.stringify(classNode.range),
       source: classNode.source,

--- a/src/file-crawler.js
+++ b/src/file-crawler.js
@@ -8,10 +8,10 @@ import SymbolProcessor, { SymbolKind } from "./symbol_parser.js";
 
 async function insertClass(symbol, file) {
   await insertClassNode(symbol);
-  await createRelationship(file.id, symbol.identifier, "DECLARES");
+  await createRelationship(file.id, symbol.id, "DECLARES");
   for (const method of symbol.methods) {
     await insertMethodNode(method);
-    await createRelationship(symbol.identifier, method.identifier, "HAS");
+    await createRelationship(symbol.id, method.id, "HAS");
   }
 }
 
@@ -51,7 +51,7 @@ export default class FileCrawler {
       ) {
         // await this.lspSugar.findAllReferences(symbol, uri);
         await insertMethodNode(symbol);
-        await createRelationship(fileNode.id, symbol.identifier, "DECLARES");
+        await createRelationship(fileNode.id, symbol.id, "DECLARES");
       }
     }
   }


### PR DESCRIPTION
removing dependencies in code graph, by having more method reuse while processing symbols

ensure id is consistently named id not identifier

## Before
![image](https://github.com/user-attachments/assets/426abaa6-16df-49a3-8452-0148558e607f)


## After
![image](https://github.com/user-attachments/assets/3ca34dbd-8f3c-476d-8c1a-dbf19e9c5791)

